### PR TITLE
openvgui integration

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vgui-dev"]
-	path = vgui-dev
-	url = https://github.com/FWGS/vgui-dev

--- a/wscript
+++ b/wscript
@@ -2,121 +2,37 @@
 # encoding: utf-8
 # mittorn, 2018
 
-from waflib import Logs
-import os
-
-top = '.'
-
-VGUI_SUPPORTED_OS = ['win32', 'darwin', 'linux']
+from waflib.TaskGen import feature, after_method
 
 def options(opt):
-	grp = opt.add_option_group('VGUI options')
-
-	vgui_dev_path = os.path.join(opt.path.path_from(opt.root), 'vgui-dev')
-
-	grp.add_option('--vgui', action = 'store', dest = 'VGUI_DEV', default=vgui_dev_path,
-		help = 'path to vgui-dev repo [default: %default]')
-
-	grp.add_option('--disable-vgui', action = 'store_true', dest = 'NO_VGUI', default = False,
-		help = 'disable vgui_support [default: %default]')
-
-	grp.add_option('--skip-vgui-sanity-check', action = 'store_false', dest = 'VGUI_SANITY_CHECK', default=True,
-		help = 'skip checking VGUI sanity [default: %default]' )
 	return
 
 def configure(conf):
-	conf.env.NO_VGUI = conf.options.NO_VGUI
-	if conf.options.NO_VGUI:
-		return
+	return
 
-	conf.start_msg('Does this architecture support VGUI?')
-
-	if conf.env.DEST_CPU != 'x86' and not (conf.env.DEST_CPU == 'x86_64' and not conf.options.ALLOW64):
-		conf.end_msg('no')
-		Logs.warn('vgui is not supported on this CPU: ' + str(conf.env.DEST_CPU))
-		conf.env.NO_VGUI = True
-		return
-	else:
-		conf.end_msg('yes')
-
-	conf.start_msg('Does this OS support VGUI?')
-	if conf.env.DEST_OS not in VGUI_SUPPORTED_OS:
-		conf.end_msg('no')
-		Logs.warn('vgui is not supported on this OS: ' + str(conf.env.DEST_OS))
-		conf.env.NO_VGUI = True
-		return
-	else:
-		conf.end_msg('yes')
-
-	conf.start_msg('Does this toolchain able to link VGUI?')
-	if conf.env.DEST_OS == 'win32' and conf.env.COMPILER_CXX == 'g++':
-		conf.end_msg('no')
-		# we have ABI incompatibility ONLY on MinGW
-		Logs.warn('vgui_support can\'t be built with MinGW')
-		conf.env.NO_VGUI = True
-		return
-	else:
-		conf.end_msg('yes')
-
-	if conf.env.NO_VGUI:
-		return
-
-	conf.start_msg('Configuring VGUI by provided path')
-	vgui_dev = conf.options.VGUI_DEV
-
-	if conf.env.DEST_OS == 'win32':
-		conf.env.LIB_VGUI = ['vgui']
-		conf.env.LIBPATH_VGUI = [os.path.abspath(os.path.join(vgui_dev, 'lib/win32_vc6/'))]
-	else:
-		libpath = os.path.abspath(os.path.join(vgui_dev, 'lib'))
-		if conf.env.DEST_OS == 'linux':
-			conf.env.LIB_VGUI = [':vgui.so']
-			conf.env.LIBPATH_VGUI = [libpath]
-		elif conf.env.DEST_OS == 'darwin':
-			conf.env.LDFLAGS_VGUI = [os.path.join(libpath, 'vgui.dylib')]
-		else:
-			conf.fatal('vgui is not supported on this OS: ' + conf.env.DEST_OS)
-	conf.env.INCLUDES_VGUI = [os.path.abspath(os.path.join(vgui_dev, 'include'))]
-
-	conf.env.HAVE_VGUI = 1
-	conf.end_msg('yes: {0}, {1}, {2}'.format(conf.env.LIB_VGUI, conf.env.LIBPATH_VGUI, conf.env.INCLUDES_VGUI))
-
-	if conf.env.HAVE_VGUI and conf.options.VGUI_SANITY_CHECK:
-		try:
-			conf.check_cxx(
-				fragment='''
-				#include <VGUI.h>
-				int main( int argc, char **argv )
-				{
-					return 0;
-				}''',
-				msg	= 'Checking for library VGUI sanity',
-				use = 'VGUI',
-				execute = False)
-		except conf.errors.ConfigurationError:
-			conf.fatal("Can't compile simple program. Check your path to vgui-dev repository.")
+@feature('fixup_link')
+@after_method('process_use')
+def fixup_link(self):
+	if self.env.cxxshlib_PATTERN.endswith('.so'):
+		fixedlibs = []
+		for lib in self.env.LIB:
+			fixedlibs += [':%s.so' % lib]
+		self.env.LIB = fixedlibs
 
 def build(bld):
-	if bld.env.NO_VGUI:
-		return
+	# in case of broken compatibility, vgui could be provided
+	# by proprietary version, rather than through uselib hack
+	# we had before
+	libs = ['sdk_includes', 'vgui']
 
-	libs = [ 'sdk_includes' ]
-
-	# basic build: dedicated only, no dependencies
 	if bld.env.DEST_OS != 'win32':
-		libs += ['DL','M']
+		libs += ['DL', 'M']
 
-	libs.append('VGUI')
-
-	source = bld.path.ant_glob(['*.cpp'])
-
-	includes = [ '.' ]
-
-	bld.shlib(
-		source   = source,
+	tsk = bld.shlib(
+		source   = bld.path.ant_glob(['*.cpp']),
 		target   = 'vgui_support',
-		features = 'cxx',
-		includes = includes,
+		features = 'cxx fixup_link',
+		includes = '.',
 		use      = libs,
 		rpath    = '$ORIGIN',
 		install_path = bld.env.LIBDIR,


### PR DESCRIPTION
Here we remove `vgui-dev` submodule. `openvgui` dependency is meant to be provided externally.

This is a part of patches sent across [`vgui_support`](https://github.com/FWGS/vgui_support/pull/2), [`openvgui`](https://github.com/FWGS/openvgui/pull/3) and [`xash3d-fwgs`](https://github.com/FWGS/xash3d-fwgs/pull/1069) repos.
