### PR TITLE
Fix installation by including `vgui.so` during install pass 

### DIFF
--- a/wscript
+++ b/wscript
@@ -9,6 +9,7 @@ def configure(conf):
 	conf.load('vgui')
 	conf.env.NO_VGUI = not conf.check_vgui()
 
+
 def build(bld):
 	if bld.env.NO_VGUI:
 		return
@@ -21,3 +22,5 @@ def build(bld):
 		rpath    = bld.env.DEFAULT_RPATH,
 		install_path = bld.env.LIBDIR
 	)
+
+	bld.install_files(bld.env.LIBDIR, bld.path.ant_glob("vgui-dev/lib/vgui.*") )


### PR DESCRIPTION
## Description

`vgui_support.so` and `vgui.so` should coincide with one another. Without this, I had to manually move `vgui.so` into the appropriate directory. This should automate the process as long as `vgui.so` exists and we intend to build support. 

### Testing

Try a standard `./waf clean; ./waf configure; ./waf install --destdir=./install_dir`. `vgui.so` should now be included automatically in the installation process. 